### PR TITLE
feat: add .moltfounders/ agent rules directory

### DIFF
--- a/.moltfounders/README.md
+++ b/.moltfounders/README.md
@@ -1,0 +1,26 @@
+# .moltfounders/
+
+This directory defines how AI agents maintain this repository.
+
+Agents participating in the [MoltFounders](https://moltfounders.com) workspace for this repo read these files on every run and follow them exactly. Rules are versioned here like code — propose changes via PR.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `labels.md` | Canonical GitHub label definitions |
+| `issue-triage.md` | How to triage and respond to issues |
+| `pr-review.md` | How to review pull requests |
+| `research.md` | How to discover and suggest new OpenClaw resources |
+| `staleness.md` | How to handle stale issues and PRs |
+
+## Principles
+
+- **Agents prepare, humans decide.** Agents review, comment, and label. Only the maintainer merges.
+- **Idempotent by default.** Once an agent has handled an item, it won't touch it again unless the label is removed.
+- **OpenClaw-focused.** This list is specifically about the OpenClaw ecosystem — not general AI tools.
+- **Community-editable.** Want to change how the repo is maintained? Open a PR against these files.
+
+## Note on quality criteria
+
+This list differs from a general OSS list — it does not require OSI-approved licenses or star thresholds. The primary bar is: **clear OpenClaw relevance + active/useful resource**. See CONTRIBUTING.md for full criteria.

--- a/.moltfounders/issue-triage.md
+++ b/.moltfounders/issue-triage.md
@@ -1,0 +1,68 @@
+# Issue Triage Rules
+
+## When to Run
+
+On every agent loop cycle, scan all open issues.
+
+## Skip Conditions
+
+- Issue already has `agent:reviewed` label → skip entirely
+- Issue was opened by an agent → skip
+- GitHub-generated issue (dependabot, etc.) → skip
+
+## Triage Steps
+
+### 1. Classify the issue type
+
+- **Addition request** — someone wants a new resource added
+- **Removal request** — entry is stale, broken, or no longer relevant
+- **Correction** — fixing a description, link, or category
+- **Question / discussion** — not a concrete change request
+- **Spam / off-topic** — unrelated to OpenClaw
+
+### 2. Evaluate based on type
+
+**Addition requests — quality bar:**
+- Does it have clear OpenClaw relevance? (Is it a skill, plugin, tool, guide, or resource for OpenClaw users?)
+- Does it have a working repo or page?
+- Is it actively maintained or at minimum a useful stable reference?
+- Is it not already in the list? (Search README before commenting)
+- Does it fit an existing category?
+
+Note: Unlike general OSS lists, this list does NOT require:
+- OSI-approved license (many tools are proprietary-friendly or not code)
+- Specific star count (small but useful OpenClaw tools are welcome)
+
+The primary bar is: **genuinely useful to OpenClaw users**.
+
+**Removal requests:**
+- Is the reason valid? (broken link, project dead, no longer OpenClaw-related)
+- Verify the claim independently.
+
+**Corrections:**
+- Is the correction accurate?
+- Does it follow CONTRIBUTING.md format?
+
+**Questions/discussions:**
+- Answer if you can from the README/CONTRIBUTING.md context
+- Label `needs-human` if it requires maintainer judgment
+
+**Spam/off-topic:**
+- Label `needs-human`, leave a polite comment explaining the repo's scope
+
+### 3. Comment
+
+Leave a clear, helpful comment with your verdict and specific feedback. Be friendly — contributors put effort in.
+
+### 4. Apply labels
+
+- Always apply `agent:reviewed` after handling
+- Apply `agent:commented` if you left a comment
+- Apply `duplicate`, `not-openclaw-related`, `needs-info`, or `broken-link` as appropriate
+- Apply `needs-human` if you cannot resolve confidently
+
+## Edge Cases
+
+- **Unclear if OpenClaw-relevant:** Label `needs-info`, ask submitter to clarify the connection
+- **Project is useful but not specifically OpenClaw:** Label `not-openclaw-related`, explain the scope
+- **Issue is very old (>90 days, no activity):** Follow staleness rules in `staleness.md`

--- a/.moltfounders/labels.md
+++ b/.moltfounders/labels.md
@@ -1,0 +1,29 @@
+# Labels
+
+Canonical GitHub labels used by agents in this repository.
+
+## Agent Labels
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `agent:reviewed` | `#0075ca` | Reviewed by an agent — will not be re-reviewed automatically |
+| `agent:commented` | `#cfd3d7` | Agent left a comment on this item |
+| `agent:approved` | `#0e8a16` | Agent approved this PR — needs maintainer merge |
+| `agent:changes-requested` | `#e4e669` | Agent requested changes on this PR |
+| `agent:suggested` | `#d4edda` | Agent suggested this entry via research loop |
+
+## Status Labels
+
+| Label | Color | Description |
+|-------|-------|-------------|
+| `needs-human` | `#e11d48` | Needs maintainer attention — agent could not resolve |
+| `stale` | `#ededed` | No activity for an extended period |
+| `duplicate` | `#cfd3d7` | Already exists in the list |
+| `not-openclaw-related` | `#b60205` | Project does not have clear OpenClaw relevance |
+| `needs-info` | `#fbca04` | Waiting on submitter for more information |
+| `broken-link` | `#e4e669` | Link in entry is broken or 404 |
+
+## Setup
+
+Agents should ensure all labels above exist in the repo before executing loops.
+If a label is missing, create it with the specified color and description via gh CLI.

--- a/.moltfounders/pr-review.md
+++ b/.moltfounders/pr-review.md
@@ -1,0 +1,76 @@
+# PR Review Rules
+
+## When to Run
+
+On every agent loop cycle, scan all open PRs.
+
+## Skip Conditions
+
+- PR already has `agent:reviewed` label → skip entirely
+- PR is a draft → skip
+- PR was opened by an agent → skip
+- Bot PR (dependabot, etc.) → label `needs-human`, skip
+
+## Review Steps
+
+### 1. Understand what the PR does
+
+Read the PR title, description, and diff carefully.
+
+### 2. Format checks
+
+- Does the entry follow the format in CONTRIBUTING.md?
+  ```
+  - [owner/repo](url) ![GitHub stars badge] - Short factual description.
+  ```
+- Is the description short, neutral, and factual (no marketing language)?
+- Is it placed in the correct section?
+- Is the link valid? (Check URL resolves)
+- Stars badge uses `?style=social` format?
+
+### 3. Content checks
+
+**OpenClaw relevance:**
+- Does it have a clear, direct connection to OpenClaw? (skill, plugin, integration, guide, tool for OpenClaw users)
+- If relevance is tenuous, ask the submitter to clarify in the PR
+
+**Activity / usefulness:**
+- Does the repo/resource exist and load?
+- Is it reasonably active or at minimum a useful stable resource?
+- Abandoned projects with no commits in 12+ months: request changes unless it's a reference/archival resource
+
+**Duplicate check:**
+- Search the current README for the repo URL and name
+- If duplicate → comment clearly, apply `duplicate` label
+
+**Category fit:**
+- Is it in the right section?
+- If it fits better elsewhere, suggest the correct section
+
+### 4. Leave your review
+
+Be specific and helpful:
+- List each issue with clear explanation
+- If approving: say exactly why it meets the bar
+- If requesting changes: give actionable feedback
+
+### 5. Apply labels and set review status
+
+- Always apply `agent:reviewed`
+- Apply `agent:approved` if the PR meets all criteria
+- Apply `agent:changes-requested` if changes needed
+- Apply relevant labels (`duplicate`, `not-openclaw-related`, `broken-link`) as needed
+- Apply `needs-human` for borderline cases or disputes
+
+## Important: Agent approval ≠ merge
+
+`agent:approved` means the PR passed automated review. **Only the maintainer merges.**
+
+## Edge Cases
+
+- **PR removes a broken link:** Fast-track approve — these are unambiguously good
+- **PR fixes formatting only:** Fast-track approve
+- **PR adds something useful but format is slightly off:** Request small formatting fix, approve the concept
+- **PR has been open >30 days with no author response:** Follow staleness rules in `staleness.md`
+- **Submitter disputes feedback:** Stand firm on objective criteria (relevance, format), label `needs-human` for subjective disputes
+- **PR adds a commercial tool with OpenClaw integration:** Fine if the integration is real and useful — commercial tools are allowed

--- a/.moltfounders/research.md
+++ b/.moltfounders/research.md
@@ -1,0 +1,50 @@
+# Research Loop Rules
+
+## Purpose
+
+Periodically discover new OpenClaw resources worth adding and open issues suggesting them.
+
+## Frequency
+
+Run once per week. Do not run if you already opened a research issue in the last 7 days (check `agent:suggested` label).
+
+## Sources to Check
+
+1. **GitHub search** — `openclaw` topic, `openclaw` in repo name, or `openclaw` in description
+2. **ClawHub** — https://clawhub.com for new published skills
+3. **OpenClaw Discord** — https://discord.com/invite/clawd (if accessible) for community projects
+4. **GitHub** — search `openclaw skill`, `openclaw plugin`, `openclaw integration`
+5. **Reddit / HN** — search for recent OpenClaw mentions
+
+## Qualification Criteria
+
+A resource is worth suggesting if:
+- Clear OpenClaw relevance (skill, plugin, integration, guide, deployment tool, etc.)
+- Has a working repo, page, or documentation
+- Not already in the list (search README before suggesting)
+- Reasonably active or a useful stable reference
+- Fits an existing category in the README
+
+## How to Suggest
+
+Open a GitHub issue with:
+- **Title:** `[Research] Add: <Project Name>`
+- **Body:**
+  - Repo/resource URL
+  - One-sentence description
+  - Suggested category
+  - Why it belongs (OpenClaw relevance)
+  - Source where you found it
+
+Apply label `agent:suggested`.
+
+## Limits
+
+- At most **3 research issues per cycle**
+- Check existing `agent:suggested` issues to avoid duplicates
+
+## Edge Cases
+
+- **Brand new project (<1 week old):** Still suggest if clearly relevant — note recency
+- **Official OpenClaw org repo not yet listed:** Definitely suggest it
+- **Skill on ClawHub not in the list:** Good candidate — suggest it

--- a/.moltfounders/staleness.md
+++ b/.moltfounders/staleness.md
@@ -1,0 +1,45 @@
+# Staleness Rules
+
+## Purpose
+
+Keep the issue tracker and PR queue clean.
+
+## Issues
+
+### Waiting on submitter (`needs-info` label)
+
+- No response after **14 days**: post a friendly reminder
+- No response after **30 days**: apply `stale` label, note will close in 7 days
+- No response after **37 days**: close with a polite note; can be reopened
+
+### General open issues
+
+- Open >90 days with no activity and no `agent:reviewed`: triage now
+- Open >90 days with `agent:reviewed` and no further activity: apply `stale`, ask if still relevant
+- Stale for another 14 days: label `needs-human` — don't close blindly
+
+## Pull Requests
+
+### PRs awaiting author action (`agent:changes-requested`)
+
+- No response after **14 days**: friendly reminder with summary of what's needed
+- No response after **30 days**: apply `stale`, note will close in 7 days
+- No response after **37 days**: close with explanation, welcome to reopen when updated
+
+### PRs with merge conflicts
+
+- Comment immediately asking for rebase
+- Not resolved after **14 days**: apply `stale`
+- Not resolved after **30 days**: close with explanation
+
+### PRs approved but not merged (`agent:approved`)
+
+- Do not mark stale — these are in the maintainer's queue
+- If approved >30 days with no merge or comment: label `needs-human`
+
+## General Principles
+
+- Always be friendly — people get busy
+- Never close without a clear comment explaining why and how to reopen
+- When in doubt: label `needs-human` rather than closing
+- Do not mark stale if there was any activity in the window


### PR DESCRIPTION
## What this adds

A `.moltfounders/` directory defining how AI agents maintain this repo.

### Files
- `README.md` — explains the directory and principles
- `labels.md` — canonical label definitions
- `issue-triage.md` — triage rules tailored for OpenClaw-specific quality bar
- `pr-review.md` — review criteria (format, relevance, duplicates)
- `research.md` — weekly discovery of new OpenClaw resources
- `staleness.md` — handling quiet issues and PRs

### Key difference from generic awesome lists
No OSI license requirement or star threshold — primary bar is **clear OpenClaw relevance + useful resource**, following CONTRIBUTING.md.

### How it works
Agent loops running on MoltFounders fetch these files fresh on every run and follow them exactly. Behavior evolves through PRs — full audit trail, community-editable.