### PR TITLE
Add InnerWarden to Security & Safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [nearai/ironclaw](https://github.com/nearai/ironclaw) ![GitHub Repo stars](https://img.shields.io/github/stars/nearai/ironclaw?style=social) - Privacy- and security-focused Rust implementation inspired by OpenClaw.
 - [NVIDIA/NemoClaw](https://github.com/NVIDIA/NemoClaw) ![GitHub Repo stars](https://img.shields.io/github/stars/NVIDIA/NemoClaw?style=social) - More secure managed runtime approach for OpenClaw-style workloads.
 - [tophant-ai/ClawVault](https://github.com/tophant-ai/ClawVault) ![GitHub Repo stars](https://img.shields.io/github/stars/tophant-ai/ClawVault?style=social) - Security vault project for tighter control around OpenClaw environments.
+- [InnerWarden/innerwarden](https://github.com/InnerWarden/innerwarden) ![GitHub Repo stars](https://img.shields.io/github/stars/InnerWarden/innerwarden?style=social) - Security agent that protects your server and AI agents. Checks commands before they run, blocks dangerous ones, alerts you on Telegram. Install: `curl -fsSL https://innerwarden.com/install | sudo bash`
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 - [nearai/ironclaw](https://github.com/nearai/ironclaw) ![GitHub Repo stars](https://img.shields.io/github/stars/nearai/ironclaw?style=social) - Privacy- and security-focused Rust implementation inspired by OpenClaw.
 - [NVIDIA/NemoClaw](https://github.com/NVIDIA/NemoClaw) ![GitHub Repo stars](https://img.shields.io/github/stars/NVIDIA/NemoClaw?style=social) - More secure managed runtime approach for OpenClaw-style workloads.
 - [tophant-ai/ClawVault](https://github.com/tophant-ai/ClawVault) ![GitHub Repo stars](https://img.shields.io/github/stars/tophant-ai/ClawVault?style=social) - Security vault project for tighter control around OpenClaw environments.
-- [InnerWarden/innerwarden](https://github.com/InnerWarden/innerwarden) ![GitHub Repo stars](https://img.shields.io/github/stars/InnerWarden/innerwarden?style=social) - Security agent that protects your server and AI agents. Checks commands before they run, blocks dangerous ones, alerts you on Telegram. Install: `curl -fsSL https://innerwarden.com/install | sudo bash`
+- [InnerWarden/innerwarden](https://github.com/InnerWarden/innerwarden) ![GitHub Repo stars](https://img.shields.io/github/stars/InnerWarden/innerwarden?style=social) - Security agent for Linux servers and AI agents — validates commands before execution, blocks dangerous ones, and captures attacker behavior.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds [InnerWarden](https://github.com/InnerWarden/innerwarden) to the Security & Safety section.

Security agent that protects Linux servers and AI agents running on them. Validates commands before execution, blocks dangerous ones, captures attacker behavior. One-line install.

Install: `curl -fsSL https://innerwarden.com/install | sudo bash`