### PR TITLE
Add ToolRouter — one gateway to 150+ tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 - [refly-ai/refly](https://github.com/refly-ai/refly) ![GitHub Repo stars](https://img.shields.io/github/stars/refly-ai/refly?style=social) - Open-source agent skills builder for creating reusable workflows and bots.
 - [unbrowse-ai/unbrowse](https://github.com/unbrowse-ai/unbrowse) ![GitHub Repo stars](https://img.shields.io/github/stars/unbrowse-ai/unbrowse?style=social) - API-native browser skill and CLI for agent workflows.
 - [libukai/awesome-agent-skills](https://github.com/libukai/awesome-agent-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/libukai/awesome-agent-skills?style=social) - Broader agent-skills guide with OpenClaw overlap.
+- [ToolRouter](https://toolrouter.com) - Give your AI agent superpowers with access to 150+ tools on demand with just one account. Competitor research, video production, web search, image generation, security scanning, and more. Works with ChatGPT, Claude, Cursor, and any MCP client. `npx -y toolrouter-mcp` | Remote: `https://api.toolrouter.com/mcp`
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds ToolRouter — give your AI agent superpowers with access to 150+ tools on demand with just one account. One API key replaces managing dozens of separate provider accounts.

Works with ChatGPT, Claude, Cursor, Windsurf, and any MCP-compatible client. Growing daily.

- Website: https://toolrouter.com
- npm: https://www.npmjs.com/package/toolrouter-mcp
- Remote MCP: https://api.toolrouter.com/mcp