### PR TITLE
Add Dakera to Memory Systems — self-hosted MCP memory server for OpenClaw agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [volcengine/OpenViking](https://github.com/volcengine/OpenViking) ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) - Open-source context database designed specifically for AI Agents through a file system paradigm.
 - [memorycrystal/memorycrystal](https://github.com/memorycrystal/memorycrystal) ![GitHub Repo stars](https://img.shields.io/github/stars/memorycrystal/memorycrystal?style=social) - Persistent cognitive memory layer with vector-indexed knowledge graph. Ships as OpenClaw plugin and MCP server.
 - [usecortex/openclaw-hydradb](https://github.com/usecortex/openclaw-hydradb) ![GitHub Repo stars](https://img.shields.io/github/stars/usecortex/openclaw-hydradb?style=social) - OpenClaw plugin for HydraDB providing agentic memory with automatic conversation capture and recall.
+- [Dakera](https://github.com/dakera-ai/dakera-mcp) ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social) - Self-hosted MCP agent memory server providing persistent, decay-weighted memory for OpenClaw agents. Integrates via MCP protocol with HNSW vector search and cross-session knowledge retention.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
## Summary

Adds [Dakera](https://github.com/dakera-ai/dakera-mcp) to the **Memory & Context Systems** section.

Dakera is a self-hosted MCP agent memory server providing persistent, decay-weighted memory for OpenClaw agents. It integrates via the MCP protocol with HNSW vector search and cross-session knowledge retention — a natural fit alongside the other memory systems listed in this section.

## Entry added

```
- [Dakera](https://github.com/dakera-ai/dakera-mcp) ![GitHub Repo stars](https://img.shields.io/github/stars/dakera-ai/dakera-mcp?style=social) - Self-hosted MCP agent memory server providing persistent, decay-weighted memory for OpenClaw agents. Integrates via MCP protocol with HNSW vector search and cross-session knowledge retention.
```

Format matches existing entries exactly (star badge + description pattern).