### PR TITLE
Add Formative Memory to Memory & Context Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 - [volcengine/OpenViking](https://github.com/volcengine/OpenViking) ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) - Open-source context database designed specifically for AI Agents through a file system paradigm.
 - [memorycrystal/memorycrystal](https://github.com/memorycrystal/memorycrystal) ![GitHub Repo stars](https://img.shields.io/github/stars/memorycrystal/memorycrystal?style=social) - Persistent cognitive memory layer with vector-indexed knowledge graph. Ships as OpenClaw plugin and MCP server.
 - [usecortex/openclaw-hydradb](https://github.com/usecortex/openclaw-hydradb) ![GitHub Repo stars](https://img.shields.io/github/stars/usecortex/openclaw-hydradb?style=social) - OpenClaw plugin for HydraDB providing agentic memory with automatic conversation capture and recall.
+- [jarimustonen/formative-memory](https://github.com/jarimustonen/formative-memory) ![GitHub Repo stars](https://img.shields.io/github/stars/jarimustonen/formative-memory?style=social) - Biologically-inspired memory plugin for OpenClaw. Pre-response hybrid (BM25 + embedding) recall with weighted associations, post-response provenance-based reinforcement, and a nightly consolidation ("sleep") loop that decays, prunes, and LLM-merges memories. SQLite + sqlite-vec, single file.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@
 - [volcengine/OpenViking](https://github.com/volcengine/OpenViking) ![GitHub Repo stars](https://img.shields.io/github/stars/volcengine/OpenViking?style=social) - Open-source context database designed specifically for AI Agents through a file system paradigm.
 - [memorycrystal/memorycrystal](https://github.com/memorycrystal/memorycrystal) ![GitHub Repo stars](https://img.shields.io/github/stars/memorycrystal/memorycrystal?style=social) - Persistent cognitive memory layer with vector-indexed knowledge graph. Ships as OpenClaw plugin and MCP server.
 - [usecortex/openclaw-hydradb](https://github.com/usecortex/openclaw-hydradb) ![GitHub Repo stars](https://img.shields.io/github/stars/usecortex/openclaw-hydradb?style=social) - OpenClaw plugin for HydraDB providing agentic memory with automatic conversation capture and recall.
-- [jarimustonen/formative-memory](https://github.com/jarimustonen/formative-memory) ![GitHub Repo stars](https://img.shields.io/github/stars/jarimustonen/formative-memory?style=social) - Biologically-inspired memory plugin for OpenClaw. Pre-response hybrid (BM25 + embedding) recall with weighted associations, post-response provenance-based reinforcement, and a nightly consolidation ("sleep") loop that decays, prunes, and LLM-merges memories. SQLite + sqlite-vec, single file.
+- [jarimustonen/formative-memory](https://github.com/jarimustonen/formative-memory) ![GitHub Repo stars](https://img.shields.io/github/stars/jarimustonen/formative-memory?style=social) - OpenClaw memory plugin with hybrid recall, provenance-based reinforcement, nightly consolidation, and SQLite/sqlite-vec storage.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adding **Formative Memory** to the Memory & Context Systems section.

- **Repo:** https://github.com/jarimustonen/formative-memory
- **License:** MIT
- **OpenClaw plugin:** yes (installs via `openclaw plugins install formative-memory`)

## What it is

A biologically-inspired memory plugin for OpenClaw. Four things on every turn:

- **Recall** — pre-response hybrid BM25 + embedding search with strength-weighted ranking and one-hop association expansion.
- **Evaluate** — attribution tracks which surfaced memories actually influenced the reply; useful ones reinforced, ignored ones decay.
- **Capture** — explicit `memory_store` or chain-of-thought auto-capture that filters durable facts from ephemeral context.
- **Consolidate** — nightly "sleep": reinforce → decay → associate → temporal shift → prune → LLM-merge. All mutation deferred here so live chat stays read-only.

## Differences from existing entries in this section

The closest neighbors are openclaw-supermemory, openclaw-engram, mem9 and memory-lancedb-pro. Distinctive points:

1. **Provenance-based reinforcement** — strength updates are driven by which memories actually influenced the reply, not by retrieval frequency.
2. **Deferred mutation** — all decay/merge/prune happens during nightly consolidation, leaving the live path read-only and predictable.
3. **Temporal states** — memories can be future/present/past with anchor dates and shift automatically during consolidation.
4. **Content addressing** (SHA-256) — duplicates are structurally impossible.
5. **Single-file storage** — SQLite + FTS5 + sqlite-vec; no external vector DB.

Happy to adjust wording or placement.