### PR TITLE
Add skill library: claude-brewcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
 - [HITsz-TMG/VideoClaw](https://github.com/HITsz-TMG/VideoClaw) ![GitHub Repo stars](https://img.shields.io/github/stars/HITsz-TMG/VideoClaw?style=social) - AI video generation coworker — chat an idea and produce a film-style output for OpenClaw-style agents.
 - [screenpipe/screenpipe](https://github.com/screenpipe/screenpipe) ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social) - Local 24/7 screen recording that plugs into OpenClaw, Hermes, and other agents (YC S26).
+- [kochetkov-ma/claude-brewcode](https://github.com/kochetkov-ma/claude-brewcode) ![GitHub Repo stars](https://img.shields.io/github/stars/kochetkov-ma/claude-brewcode?style=social) - OpenClaw skill library including the `brewpage-publish` skill for publishing HTML, Markdown, JSON, and files to brewpage.app.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds a new entry to the **🧰 Skills & Registries** section.

**Resource:** [kochetkov-ma/claude-brewcode](https://github.com/kochetkov-ma/claude-brewcode)

**Category:** Skills & Registries (it is an OpenClaw skill library).

**Description (one sentence, factual):**
> OpenClaw skill library including the `brewpage-publish` skill for publishing HTML, Markdown, JSON, and files to brewpage.app.

**Why it is relevant to OpenClaw:**
- It is an active OpenClaw skill library — it ships an `openclaw/` directory of skills installable via `openclaw skills install <name>`.
- One of its skills, `brewpage-publish`, is live on ClawHub: https://clawhub.ai/kochetkov-ma/brewpage-publish (MIT-0).
- Latest meaningful commit is within the last 30 days (pushed 2026-05-31), satisfying the activity rule in CONTRIBUTING.

**Checklist:**
- [x] Link works
- [x] Project is relevant to OpenClaw
- [x] Description is concise and neutral
- [x] Entry placed in the right section (Skills & Registries)
- [x] Same repo is not already listed elsewhere in the README