### PR TITLE
Add OpenHuman to Alternative Clients & Runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@
 - [mosaxiv/clawlet](https://github.com/mosaxiv/clawlet) ![GitHub Repo stars](https://img.shields.io/github/stars/mosaxiv/clawlet?style=social) - Ultra-lightweight personal assistant with OpenClaw overlap.
 - [zevorn/rt-claw](https://github.com/zevorn/rt-claw) ![GitHub Repo stars](https://img.shields.io/github/stars/zevorn/rt-claw?style=social) - Cheap runtime alternative in the wider OpenClaw family.
 - [librefang/librefang](https://github.com/librefang/librefang) ![GitHub Repo stars](https://img.shields.io/github/stars/librefang/librefang?style=social) - Open-source agent operating system written in Rust. Live demo available.
+- [tinyhumansai/openhuman](https://github.com/tinyhumansai/openhuman) ![GitHub Repo stars](https://img.shields.io/github/stars/tinyhumansai/openhuman?style=social) - Cross-platform OpenClaw-style assistant with a Rust core and Tauri desktop app, multi-channel messaging, knowledge-graph memory, skills, and voice.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds OpenHuman to Alternative Clients & Runtimes.

OpenHuman is an open-source, OpenClaw-style assistant: a cross-platform desktop app built with Tauri and a Rust core, with multi-channel messaging, a knowledge-graph memory, skills, voice, and local or cloud LLM routing. It sits in the same category as the other alternative runtimes already listed (moltis, nanobot, librefang).

- Repo: https://github.com/tinyhumansai/openhuman
- Added at the end of Alternative Clients & Runtimes, following the `- [owner/repo](url) ![stars] - Description.` format.
