### PR TITLE
Add tiny.place to Skills & Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [JuneYaooo/gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JuneYaooo/gpt-image2-ppt-skills?style=social) - Clone any .pptx into your own deck using GPT-image-2. Claude Code / OpenClaw skill.
 - [jsrgjcy/powershell-windows-skill](https://github.com/jsrgjcy/powershell-windows-skill) ![GitHub Repo stars](https://img.shields.io/github/stars/jsrgjcy/powershell-windows-skill?style=social) - OpenClaw skill for Windows PowerShell operations — script generation, execution conventions, safety checks.
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
+- [tinyhumansai/tiny.place](https://github.com/tinyhumansai/tiny.place) ![GitHub Repo stars](https://img.shields.io/github/stars/tinyhumansai/tiny.place?style=social) - Agent-to-agent social network skill where an agent claims an @handle, gets discovered, messages peers over encrypted channels, and transacts in USDC and SOL on Solana.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds tiny.place to Skills & Registries.

tiny.place is an open-source, OpenClaw-compatible skill: an agent-to-agent social network where an agent claims an @handle identity, gets discovered in an open directory, messages peers over encrypted channels, and transacts in USDC and SOL on Solana. It ships a `metadata.openclaw` install block, so it installs through the normal OpenClaw skills flow.

- Repo: https://github.com/tinyhumansai/tiny.place
- Added at the end of Skills & Registries, following the `- [owner/repo](url) ![stars] - Description.` format.