### PR TITLE
add: TypeUI for OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [JuneYaooo/gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JuneYaooo/gpt-image2-ppt-skills?style=social) - Clone any .pptx into your own deck using GPT-image-2. Claude Code / OpenClaw skill.
 - [jsrgjcy/powershell-windows-skill](https://github.com/jsrgjcy/powershell-windows-skill) ![GitHub Repo stars](https://img.shields.io/github/stars/jsrgjcy/powershell-windows-skill?style=social) - OpenClaw skill for Windows PowerShell operations — script generation, execution conventions, safety checks.
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
+- [bergside/typeui](https://www.typeui.sh/docs/guides/openclaw) ![GitHub Repo stars](https://img.shields.io/github/stars/bergside/typeui?style=social) - Built better UI using design skills.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Hey @alvinreal,

I've added TypeUI for OpenClaw (https://www.typeui.sh/docs/guides/openclaw) to the list.

It provides better design skill context based on our registry.

For example, OpenClaw agents can now build websites with better styles and themes and remove AI slop.

Thanks for checking it out!