### PR TITLE
Add avansaber/erpclaw to Skills & Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [JuneYaooo/gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JuneYaooo/gpt-image2-ppt-skills?style=social) - Clone any .pptx into your own deck using GPT-image-2. Claude Code / OpenClaw skill.
 - [jsrgjcy/powershell-windows-skill](https://github.com/jsrgjcy/powershell-windows-skill) ![GitHub Repo stars](https://img.shields.io/github/stars/jsrgjcy/powershell-windows-skill?style=social) - OpenClaw skill for Windows PowerShell operations — script generation, execution conventions, safety checks.
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
+- [avansaber/erpclaw](https://github.com/avansaber/erpclaw) ![GitHub Repo stars](https://img.shields.io/github/stars/avansaber/erpclaw?style=social) - Self-hosted open-source ERP skill suite for invoicing, inventory, payroll, and double-entry accounting in plain English.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds one entry to Skills & Registries.

- **Link:** https://github.com/avansaber/erpclaw
- **Category:** Skills & Registries
- **Description:** Self-hosted open-source ERP skill suite for invoicing, inventory, payroll, and double-entry accounting in plain English.
- **OpenClaw relevance:** It is an OpenClaw skill suite, installable via ClawHub (https://clawhub.ai/mailnike/erpclaw, latest 4.12.1) or the GitHub repo. Actively maintained; latest release shipped this week. Built by AvanSaber, GPL v3.

Checked before opening: link works, not already listed elsewhere in the README, entry follows the stars-badge format, placed at the end of its section.