### PR TITLE
Add nika to Security & Safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@
 - [christinminor459/OnionClaw](https://github.com/christinminor459/OnionClaw) ![GitHub Repo stars](https://img.shields.io/github/stars/christinminor459/OnionClaw?style=social) - Provide AI agents with full Tor network access and dark web data through a zero-config OpenClaw skill or standalone tool.
 - [getaxonflow/axonflow-openclaw-plugin](https://github.com/getaxonflow/axonflow-openclaw-plugin) ![GitHub Repo stars](https://img.shields.io/github/stars/getaxonflow/axonflow-openclaw-plugin?style=social) - AxonFlow governance for OpenClaw agents — block dangerous tools, govern MCP access, and keep audit trails.
 - [secr-dev/openclaw-plugin](https://github.com/secr-dev/openclaw-plugin) ![GitHub Repo stars](https://img.shields.io/github/stars/secr-dev/openclaw-plugin?style=social) - Native secrets manager plugin for OpenClaw — brokers credentials, enforces per-agent allowlists, gates tool calls through MCP with approval queues.
+- [supernovae-st/nika](https://github.com/supernovae-st/nika) ![GitHub Repo stars](https://img.shields.io/github/stars/supernovae-st/nika?style=social) - Deterministic workflow runner agents delegate repeatable jobs to — every .nika.yaml is checked before a token is spent (plan, cost floor, secret flows, default-deny permits) and leaves a tamper-evident hash-chained trace.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Disclosure: I maintain nika (github.com/supernovae-st/nika), an open-source AGPL-3.0 project. Adding one entry at the end of **Security & Safety**, matching the list's `[owner/repo] + stars badge + description` format.

**Why this section:** nika is the safety layer for delegated agent work — the same shelf as rampart (policy before execution) and dashclaw (replayable audit trails). An agent hands the repeatable slice of a job to a `.nika.yaml` file; `nika check` audits it statically before a single token is spent (the plan, an honest cost floor, which secrets flow into which step, and a default-deny permits boundary), and every run leaves a hash-chained trace that `nika trace verify` confirms or breaks. Cross-tool like rampart: works alongside OpenClaw, Claude Code, Codex, or any agent that can run a CLI.

Verifiable in two commands, offline, zero keys: `brew install supernovae-st/tap/nika` then `nika examples run 01-hello --model mock/echo`. Happy to adjust placement or wording.