### PR TITLE
docs: add deciqAI/knowledge-skills to Skills & Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [JuneYaooo/gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JuneYaooo/gpt-image2-ppt-skills?style=social) - Clone any .pptx into your own deck using GPT-image-2. Claude Code / OpenClaw skill.
 - [jsrgjcy/powershell-windows-skill](https://github.com/jsrgjcy/powershell-windows-skill) ![GitHub Repo stars](https://img.shields.io/github/stars/jsrgjcy/powershell-windows-skill?style=social) - OpenClaw skill for Windows PowerShell operations — script generation, execution conventions, safety checks.
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
+- [deciqAI/knowledge-skills](https://github.com/deciqAI/knowledge-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/deciqAI/knowledge-skills?style=social) - Library of 227 reasoning-framework skills (first-principles, inversion, Bayesian, BATNA/ZOPA) published on ClawHub.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 - [JuneYaooo/gpt-image2-ppt-skills](https://github.com/JuneYaooo/gpt-image2-ppt-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/JuneYaooo/gpt-image2-ppt-skills?style=social) - Clone any .pptx into your own deck using GPT-image-2. Claude Code / OpenClaw skill.
 - [jsrgjcy/powershell-windows-skill](https://github.com/jsrgjcy/powershell-windows-skill) ![GitHub Repo stars](https://img.shields.io/github/stars/jsrgjcy/powershell-windows-skill?style=social) - OpenClaw skill for Windows PowerShell operations — script generation, execution conventions, safety checks.
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
-- [deciqAI/knowledge-skills](https://github.com/deciqAI/knowledge-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/deciqAI/knowledge-skills?style=social) - Library of 227 reasoning-framework skills (first-principles, inversion, Bayesian, BATNA/ZOPA) published on ClawHub.
+- [deciqAI/knowledge-skills](https://github.com/deciqAI/knowledge-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/deciqAI/knowledge-skills?style=social) - Library of reasoning-framework skills (first-principles, inversion, Bayesian, BATNA/ZOPA) published on ClawHub.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds [deciqAI/knowledge-skills](https://github.com/deciqAI/knowledge-skills) to Skills & Registries.

Open-source library of reasoning-framework skills (first-principles, inversion, Bayesian, BATNA/ZOPA), MIT, published on ClawHub. Latest commit is recent (within your 30-day rule).

Disclosure: I'm affiliated with deciqAI.