### PR TITLE
docs(readme): add clawdbot.tech to Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@
 - [liyupi/ai-guide](https://github.com/liyupi/ai-guide) ![GitHub Repo stars](https://img.shields.io/github/stars/liyupi/ai-guide?style=social) - Broad Chinese AI resource guide including OpenClaw onboarding tutorials and practical model usage.
 - [centminmod/explain-openclaw](https://github.com/centminmod/explain-openclaw) ![GitHub Repo stars](https://img.shields.io/github/stars/centminmod/explain-openclaw?style=social) - Multi-AI documentation covering architecture, security, and deployment.
 - [shuolucs/Awesome-OpenClaw-Research](https://github.com/shuolucs/Awesome-OpenClaw-Research) ![GitHub Repo stars](https://img.shields.io/github/stars/shuolucs/Awesome-OpenClaw-Research?style=social) - Research-oriented collection of papers, analyses, and resources on the OpenClaw ecosystem.
+- [clawdbot.tech](https://clawdbot.tech/) - Multilingual deployment archive for OpenClaw (formerly Clawdbot / Moltbot) covering Mac/Win/Linux/NAS, security whitepaper, FAQ, and the project's rename history across 6 languages.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
## What
Adds [clawdbot.tech](https://clawdbot.tech/) to Learning Resources.

## Why it belongs
- Multilingual deployment guide for OpenClaw, with Clawdbot → Moltbot → OpenClaw history documented inline.
- Covers Mac/Win/Linux/NAS, Docker, VPS, security whitepaper, troubleshooting and FAQ.
- Complements existing learning entries such as hello-claw, awesome-openclaw-tutorial and explain-openclaw by filling the multilingual deployment archive slot.
- Description is short, factual and placed in the existing Learning Resources category.