### PR TITLE
Add ZeroPointRepo/youtube-skills to Skills & Registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
 - [HITsz-TMG/VideoClaw](https://github.com/HITsz-TMG/VideoClaw) ![GitHub Repo stars](https://img.shields.io/github/stars/HITsz-TMG/VideoClaw?style=social) - AI video generation coworker — chat an idea and produce a film-style output for OpenClaw-style agents.
 - [screenpipe/screenpipe](https://github.com/screenpipe/screenpipe) ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social) - Local 24/7 screen recording that plugs into OpenClaw, Hermes, and other agents (YC S26).
+- [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) ![GitHub Repo stars](https://img.shields.io/github/stars/ZeroPointRepo/youtube-skills?style=social) - Agent skills for YouTube transcripts, video and channel search, channel browsing, and playlist extraction, installable on OpenClaw from ClawHub.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
Adds `ZeroPointRepo/youtube-skills` to **🧰 Skills & Registries**.

**What it is:** an MIT licensed agent skills pack that gives an agent YouTube transcripts, video and channel search, channel browsing, within channel search, and playlist extraction. Twelve skills in the repo, `youtube-full` being the combined one.

**OpenClaw relevance:**
- Published on ClawHub and installable with `npx clawhub@latest install youtube-full` (https://www.clawhub.ai/therohitdas/youtube-full)
- Repo topics include `openclaw` and `clawdbot`, and OpenClaw is the first runtime documented in the README install section
- Also works with Hermes Agent, Claude Code, Cursor and other Agent Skills compatible runtimes

**Against the contribution rules:**
- Working repository, MIT licensed, 514 stars
- Latest meaningful commit 2026-08-12, inside the 30 day window
- No existing entry for this repo or for TranscriptAPI anywhere in the README
- One line, README.md only, appended to the existing Skills & Registries category
- Standard entry format with the GitHub stars badge

**Disclosure:** I maintain this repo and the TranscriptAPI backend it calls. The skills are free and MIT licensed, and the API has a free tier for new accounts. Happy to reword or move the entry if you prefer a different category or a shorter description.
