### PR TITLE
Add Agent QA to skills and registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 - [JunjieYu95/glancely](https://github.com/JunjieYu95/glancely) ![GitHub Repo stars](https://img.shields.io/github/stars/JunjieYu95/glancely?style=social) - All-in-one personal tracker skill bundle — diary, mood, reminders, daily MIT with read-only dashboard.
 - [HITsz-TMG/VideoClaw](https://github.com/HITsz-TMG/VideoClaw) ![GitHub Repo stars](https://img.shields.io/github/stars/HITsz-TMG/VideoClaw?style=social) - AI video generation coworker — chat an idea and produce a film-style output for OpenClaw-style agents.
 - [screenpipe/screenpipe](https://github.com/screenpipe/screenpipe) ![GitHub Repo stars](https://img.shields.io/github/stars/screenpipe/screenpipe?style=social) - Local 24/7 screen recording that plugs into OpenClaw, Hermes, and other agents (YC S26).
+- [vostride/agent-qa](https://github.com/vostride/agent-qa) ![GitHub Repo stars](https://img.shields.io/github/stars/vostride/agent-qa?style=social) - Open-source product QA agent with three portable Agent Skills and an MCP server for natural-language web and mobile testing.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
## Summary

- add `vostride/agent-qa` to Skills & Registries
- use the repository's canonical GitHub-link, dynamic-star-badge, and neutral one-sentence format
- describe the three portable Agent Skills and standard MCP server that make the QA workflows usable from agent hosts

Agent QA is an open-source product-QA agent for natural-language web and mobile testing. The project was meaningfully updated within the list's 30-day activity window.

Project: https://github.com/vostride/agent-qa

## Validation

- searched the list for duplicates
- `git diff --check`
- verified the repository and skill links
