### PR TITLE
Add Molted (managed OpenClaw fleet hosting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 - [miaoxworld/OpenClawInstaller](https://github.com/miaoxworld/OpenClawInstaller) ![GitHub Repo stars](https://img.shields.io/github/stars/miaoxworld/OpenClawInstaller?style=social) - One-click installer for OpenClaw setups.
 - [justlovemaki/openclaw-docker-cn-im](https://github.com/justlovemaki/openclaw-docker-cn-im) ![GitHub Repo stars](https://img.shields.io/github/stars/justlovemaki/openclaw-docker-cn-im?style=social) - Docker distribution preconfigured for major Chinese IM integrations.
 - [linuxhsj/openclaw-zero-token](https://github.com/linuxhsj/openclaw-zero-token) ![GitHub Repo stars](https://img.shields.io/github/stars/linuxhsj/openclaw-zero-token?style=social) - Run OpenClaw against major AI models without traditional API tokens.
+- [Molted](https://www.molted.net) - Managed hosting platform built for operating fleets of OpenClaw agents: auto-healing recovery with post-mortems, versioned agent state with point-in-time restore, per-instance version pinning, and per-agent email, phone, browser and integrations.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
This adds Molted to Deployment & Operations. Disclosure up front: I am part of the team building it.

Molted is a managed hosting platform built specifically for operating fleets of OpenClaw agents, rather than single instances: auto-healing (crash detection under 60 seconds, recovery under 90 seconds, a post-mortem written for every failure), versioned files with point-in-time restore, managed per-instance OpenClaw version pinning and rollback, and per-agent email, phone number, browser automation and 1,000+ integrations. It has been in production since January 2026 and actively maintained; the same team runs molted.cloud on top of it with 11,000+ instances hosted.

It is a product page rather than a repo, so I left out the star badge and kept the entry factual per your contribution guidelines. If you consider hosted platforms out of scope for this section, feel free to close, no hard feelings.