### PR TITLE
Add openclaw-safe-first-run checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@
 ## 🎓 Learning Resources
 
 - [alvinunreal/awesome-openclaw-tips](https://github.com/alvinunreal/awesome-openclaw-tips) ![GitHub Repo stars](https://img.shields.io/github/stars/alvinunreal/awesome-openclaw-tips?style=social) - Curated OpenClaw tips, setup advice, and practical usage guidance.
+- [starqazstar/openclaw-safe-first-run](https://github.com/starqazstar/openclaw-safe-first-run) ![GitHub Repo stars](https://img.shields.io/github/stars/starqazstar/openclaw-safe-first-run?style=social) - Safety-first first-session checklist — sender allowlists, credential hygiene, spending caps, and risk by route (EN/中文).
 - [hesamsheikh/awesome-openclaw-usecases](https://github.com/hesamsheikh/awesome-openclaw-usecases) ![GitHub Repo stars](https://img.shields.io/github/stars/hesamsheikh/awesome-openclaw-usecases?style=social) - Real-world use cases and applied examples.
 - [AlexAnys/awesome-openclaw-usecases-zh](https://github.com/AlexAnys/awesome-openclaw-usecases-zh) ![GitHub Repo stars](https://img.shields.io/github/stars/AlexAnys/awesome-openclaw-usecases-zh?style=social) - Chinese OpenClaw use-case collection covering office, content, ops, and knowledge-management scenarios.
 - [datawhalechina/hello-claw](https://github.com/datawhalechina/hello-claw) ![GitHub Repo stars](https://img.shields.io/github/stars/datawhalechina/hello-claw?style=social) - Structured Chinese tutorial for getting started with OpenClaw.


### PR DESCRIPTION
Adds [openclaw-safe-first-run](https://github.com/starqazstar/openclaw-safe-first-run) to Learning Resources — a one-page, safety-first checklist for a first OpenClaw session (allowed-sender scoping, credential hygiene, spending caps, risk by route for local/VPS/hosted), with companion guides in English and Chinese. Independent community resource, MIT licensed, actively maintained.