### PR TITLE
Restore MoltFounders maintenance rules

### DIFF
--- a/.moltfounders/issue-triage.md
+++ b/.moltfounders/issue-triage.md
@@ -1,0 +1,32 @@
+# Issue Triage Rules
+
+Agents triage open issues for the `awesome-openclaw` list. Agents do not close issues.
+
+## Scope
+
+Triage open issues in `alvinreal/awesome-openclaw` that do not already have `agent:reviewed`.
+
+## Triage Checklist
+
+- Identify whether the issue suggests a resource, reports a broken link, asks a question, or needs maintainer judgment.
+- Confirm clear OpenClaw relevance for suggested resources.
+- Search `README.md` and open issues or pull requests for duplicates.
+- Check submitted links for reachability and obvious correctness.
+- Do not reject a resource only for low stars or missing OSI licensing.
+- Escalate sponsorship, policy, governance, or ambiguous editorial decisions with `needs-human`.
+
+## Comment Format
+
+Leave a concise triage comment with:
+
+- `Triage:` short classification.
+- `Finding:` what was checked and what should happen next.
+- `Labels:` labels applied or labels that could not be applied.
+
+## Labels
+
+- Apply `duplicate`, `not-openclaw-related`, `needs-info`, `broken-link`, `inactive`, or `needs-human` when appropriate.
+- Apply normal GitHub labels such as `documentation`, `enhancement`, or `question` when they fit.
+- Apply `agent:reviewed` after the triage comment is posted.
+
+If the item is valid but better handled as a pull request, say that in the comment and apply `needs-human` only when maintainer action is required.

--- a/.moltfounders/labels.md
+++ b/.moltfounders/labels.md
@@ -1,0 +1,33 @@
+# Label Rules
+
+These labels support automated maintenance. Keep names stable so agents can make idempotent decisions.
+
+## Agent Labels
+
+| Label | Use |
+| --- | --- |
+| `agent:reviewed` | An agent completed the applicable review or triage pass. Agents must skip items carrying this label. |
+| `agent:commented` | An agent left a substantive comment. |
+| `agent:approved` | An agent found a pull request acceptable for maintainer consideration. This is not merge approval. |
+| `agent:changes-requested` | An agent found issues that should be addressed before maintainer review. |
+| `agent:suggested` | An agent created or suggested an entry through the research loop. |
+
+## Status Labels
+
+| Label | Use |
+| --- | --- |
+| `needs-human` | The item needs maintainer judgment or external input. |
+| `stale` | The item has had no meaningful activity for the staleness window. |
+| `duplicate` | The resource or request already exists in the list or in another open item. |
+| `not-openclaw-related` | The item lacks clear OpenClaw ecosystem relevance. |
+| `needs-info` | More information is required from the submitter. |
+| `broken-link` | A submitted link is unavailable or resolves to the wrong resource. |
+| `license-issue` | Licensing is unclear or incompatible with the submitted resource. |
+| `inactive` | The resource appears inactive by the current project freshness bar. |
+
+## Application Rules
+
+- Create any missing labels before applying them.
+- Do not remove human-applied labels unless a maintainer explicitly requests it.
+- Apply `agent:reviewed` only after the required comment and status labels are in place.
+- Use `needs-human` instead of guessing when a decision depends on maintainer intent.

--- a/.moltfounders/pr-review.md
+++ b/.moltfounders/pr-review.md
@@ -1,0 +1,34 @@
+# PR Review Rules
+
+Agents review pull requests for maintainer consideration. Agents never merge.
+
+## Scope
+
+Review open, non-draft pull requests in `alvinreal/awesome-openclaw` that do not already have `agent:reviewed`.
+
+## Review Checklist
+
+- Confirm the submitted resource has clear OpenClaw ecosystem relevance.
+- Check whether the resource or a close duplicate already appears in `README.md` or another open pull request.
+- Verify the resource belongs in the chosen category; suggest a better category if needed.
+- Prefer concise, factual descriptions that explain what the resource does.
+- Check that links resolve to the intended resource.
+- Do not require an OSI license or star threshold. The quality bar is useful, active, and clearly relevant to OpenClaw.
+- Treat obvious spam, unrelated projects, dead links, and low-signal placeholders as changes requested.
+
+## Comment Format
+
+Leave a concise review comment with:
+
+- `Verdict:` `Looks good for maintainer review` or `Changes requested`.
+- `Notes:` specific findings, including duplicates or category concerns.
+- `Labels:` the labels applied or the label that could not be applied.
+
+## Labels
+
+- Apply `agent:approved` when the PR is acceptable for maintainer review.
+- Apply `agent:changes-requested` when the PR needs submitter action.
+- Apply any relevant status labels from `labels.md`.
+- Apply `agent:reviewed` after the review comment is posted.
+
+If label writes fail, still leave the review comment and include the failed label operation in the loop signoff or local state.

--- a/.moltfounders/research.md
+++ b/.moltfounders/research.md
@@ -1,0 +1,36 @@
+# Research Rules
+
+Agents may suggest high-signal OpenClaw ecosystem resources through pull requests.
+
+## Scope
+
+Research should add at most five qualifying resources per cycle and avoid duplicating existing README entries or open pull requests.
+
+## Candidate Bar
+
+A candidate should:
+
+- Be clearly useful to OpenClaw users, operators, plugin authors, skill authors, or adjacent OpenClaw-style agent workflows.
+- Have a reachable canonical URL.
+- Show enough activity, documentation, or adoption to be useful to readers.
+- Fit one existing README category cleanly.
+
+Do not require an OSI license or a minimum star count. Do skip low-effort placeholders, generic AI tools with no OpenClaw relevance, spam, and abandoned resources with no useful documentation.
+
+## README Format
+
+Use the local README format already present in the target section:
+
+```markdown
+- [owner/name](https://github.com/owner/name) ![GitHub Repo stars](https://img.shields.io/github/stars/owner/name?style=social) - Concise factual description.
+```
+
+Keep descriptions short and specific. Avoid marketing language.
+
+## PR Rules
+
+- Work on a branch named `research/<date>-<category>` when practical.
+- Commit with `Add: <Name> to <Category>` for a single-resource addition, or a concise research summary for multiple additions.
+- Create a PR titled `[Research] Add entries to <Category> - <Date>`.
+- Apply `agent:suggested` and `agent:reviewed` if label permissions allow.
+- Never merge the PR.

--- a/.moltfounders/staleness.md
+++ b/.moltfounders/staleness.md
@@ -1,0 +1,25 @@
+# Staleness Rules
+
+Agents help surface old issues and pull requests without closing them unilaterally.
+
+## Scope
+
+Review open issues and pull requests in `alvinreal/awesome-openclaw`.
+
+## Windows
+
+- Consider an issue or pull request stale after 30 days without meaningful activity.
+- Consider `needs-info` items stale after 14 days without a submitter response.
+- Do not mark an item stale if a maintainer commented in the last 14 days.
+
+## Actions
+
+- For stale issues, post a short reminder asking whether the item is still relevant, then apply `stale`.
+- For stale pull requests, post a short reminder asking the author to rebase, respond, or confirm the resource is still relevant, then apply `stale`.
+- Apply `needs-human` when the next step requires maintainer judgment.
+- Never close issues or pull requests.
+- Do not repeat a stale reminder if an agent already posted one recently.
+
+## Comment Format
+
+Use a concise comment that states the item appears inactive and identifies the next expected action. Avoid long summaries.


### PR DESCRIPTION
## Summary
- Restore the missing .moltfounders rule documents referenced by the MoltFounders project loops
- Define conservative label, issue triage, PR review, research, and staleness rules based on the project About.md and existing label config
- Keep maintainer merge authority explicit while unblocking future agent maintenance runs

## Notes
- Current MoltFounders loops cannot fetch their required rule sources because .moltfounders files are absent from main.
- This PR only adds rule docs; it does not modify README entries or close/merge anything.