### PR TITLE
Add OrcaReplay to Deployment & Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@
 - [miaoxworld/OpenClawInstaller](https://github.com/miaoxworld/OpenClawInstaller) ![GitHub Repo stars](https://img.shields.io/github/stars/miaoxworld/OpenClawInstaller?style=social) - One-click installer for OpenClaw setups.
 - [justlovemaki/openclaw-docker-cn-im](https://github.com/justlovemaki/openclaw-docker-cn-im) ![GitHub Repo stars](https://img.shields.io/github/stars/justlovemaki/openclaw-docker-cn-im?style=social) - Docker distribution preconfigured for major Chinese IM integrations.
 - [linuxhsj/openclaw-zero-token](https://github.com/linuxhsj/openclaw-zero-token) ![GitHub Repo stars](https://img.shields.io/github/stars/linuxhsj/openclaw-zero-token?style=social) - Run OpenClaw against major AI models without traditional API tokens.
+- [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) ![GitHub Repo stars](https://img.shields.io/github/stars/Continuum-AI-Corp/OrcaReplay?style=social) - Records an OpenClaw run and replays it offline byte-for-byte, or forks it from any step onto a different model. Catches the gateway's own calls with a fetch hook and the coding agents it spawns through inherited environment variables, so one recording covers both.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@
 - [miaoxworld/OpenClawInstaller](https://github.com/miaoxworld/OpenClawInstaller) ![GitHub Repo stars](https://img.shields.io/github/stars/miaoxworld/OpenClawInstaller?style=social) - One-click installer for OpenClaw setups.
 - [justlovemaki/openclaw-docker-cn-im](https://github.com/justlovemaki/openclaw-docker-cn-im) ![GitHub Repo stars](https://img.shields.io/github/stars/justlovemaki/openclaw-docker-cn-im?style=social) - Docker distribution preconfigured for major Chinese IM integrations.
 - [linuxhsj/openclaw-zero-token](https://github.com/linuxhsj/openclaw-zero-token) ![GitHub Repo stars](https://img.shields.io/github/stars/linuxhsj/openclaw-zero-token?style=social) - Run OpenClaw against major AI models without traditional API tokens.
-- [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) ![GitHub Repo stars](https://img.shields.io/github/stars/Continuum-AI-Corp/OrcaReplay?style=social) - Records an OpenClaw run and replays it offline byte-for-byte, or forks it from any step onto a different model. Catches the gateway's own calls with a fetch hook and the coding agents it spawns through inherited environment variables, so one recording covers both.
+- [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) ![GitHub Repo stars](https://img.shields.io/github/stars/Continuum-AI-Corp/OrcaReplay?style=social) - Records an OpenClaw run and replays it offline with the network off, or forks it from any step onto a different model. Catches the gateway's own calls with a fetch hook and the coding agents it spawns through inherited environment variables, so one recording covers both.
 
 <p align="right"><a href="#contents">⬆️ Back to Top</a></p>
 


### PR DESCRIPTION
One line added to `## 🚀 Deployment & Operations`.

## What it is

[OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) records an OpenClaw run and replays it offline byte-for-byte, or forks it from any step onto a different model.

```console
orca record openclaw
orca replay last                          # same run again, network off
orca replay last --from 4 --model <other>
```

## Why it is specifically an OpenClaw problem

OpenClaw does not do the coding itself — it runs Claude Code, Codex or opencode as child processes and drives them from a chat app. So one session carries two kinds of model traffic, and a tool that only watches one of them sees half the story.

OrcaReplay catches both: the gateway's own calls through a fetch hook, and the coding agents it spawns through the ordinary base-URL variables — not because OpenClaw forwards them, but because a child process inherits its parent's environment. Everything lands on one timeline ordered by when it actually happened, alongside shell exit codes, per-turn file changes and MCP calls.

That is the difference between "the bot replied something odd at 2am" and being able to point at the tool call that did it, then re-run the whole thing at 9am with the network off.

## Against the contribution bar

- **Clear, direct OpenClaw relevance** — `orca record openclaw` is a first-class path with a dedicated adapter (`packages/adapters/src/openclaw.ts`) and a fixture pinning the variables it sets, so a rename turns CI red instead of producing an empty recording
- **Working repository and docs** — https://github.com/Continuum-AI-Corp/OrcaReplay, README has a section on gateway-launches-the-agent setups
- **Commit within 30 days** — commits this week
- **Specific, understandable purpose** — record, replay, fork
- **Fits an existing category** — I put it in Deployment & Operations next to the observability-flavoured entries (`mnfst/manifest`, `openclaw-guardian`). If you would rather it sat elsewhere, say the word

Apache-2.0, Node 20+, npm `orcareplay`. The trace format is a separately published spec (CC BY 4.0) so readers can be reimplemented.

Disclosure: I work on OrcaReplay.
